### PR TITLE
Add ROS2 engineering calculator package

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,35 @@ Pull requests are welcome. For major changes, please open an issue first to disc
 ## License
 
 [MIT](LICENSE) (placeholder)
+
+## Engineering Calculator ROS2 Package
+
+This repository contains a ROS 2 (Foxy) package called `engineering_calculator`.
+The package provides a service named `calculate_expression` that evaluates
+mathematical expressions using a safe parser. The service returns the computed
+result or an error message.
+
+### Building and Running
+
+1. Install ROS 2 Foxy and source your ROS 2 environment.
+2. Build the package using `colcon build`:
+
+```bash
+colcon build --packages-select engineering_calculator
+```
+
+3. Source the workspace and run the service node:
+
+```bash
+. install/setup.bash
+ros2 run engineering_calculator calculator_server
+```
+
+### Testing
+
+The expression evaluator can be tested without ROS 2 using `pytest`:
+
+```bash
+pytest engineering_calculator/test
+```
+

--- a/engineering_calculator/engineering_calculator/calc_lib.py
+++ b/engineering_calculator/engineering_calculator/calc_lib.py
@@ -1,0 +1,68 @@
+import ast
+import operator
+import math
+
+# Allowed binary operators mapping from ast to functions
+_ALLOWED_OPERATORS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.Pow: operator.pow,
+    ast.Mod: operator.mod,
+}
+
+_ALLOWED_UNARY_OPERATORS = {
+    ast.UAdd: operator.pos,
+    ast.USub: operator.neg,
+}
+
+_ALLOWED_FUNCTIONS = {
+    'sin': math.sin,
+    'cos': math.cos,
+    'tan': math.tan,
+    'sqrt': math.sqrt,
+    'log': math.log,
+    'exp': math.exp,
+}
+
+
+class SafeEval(ast.NodeVisitor):
+    def visit(self, node):
+        if isinstance(node, ast.Expression):
+            return self.visit(node.body)
+        elif isinstance(node, ast.Num):
+            return node.n
+        elif isinstance(node, ast.BinOp):
+            op_type = type(node.op)
+            if op_type not in _ALLOWED_OPERATORS:
+                raise ValueError(f"Operator {op_type} not allowed")
+            left = self.visit(node.left)
+            right = self.visit(node.right)
+            return _ALLOWED_OPERATORS[op_type](left, right)
+        elif isinstance(node, ast.UnaryOp):
+            op_type = type(node.op)
+            if op_type not in _ALLOWED_UNARY_OPERATORS:
+                raise ValueError(f"Unary operator {op_type} not allowed")
+            operand = self.visit(node.operand)
+            return _ALLOWED_UNARY_OPERATORS[op_type](operand)
+        elif isinstance(node, ast.Call):
+            if not isinstance(node.func, ast.Name):
+                raise ValueError("Only simple function calls allowed")
+            func_name = node.func.id
+            if func_name not in _ALLOWED_FUNCTIONS:
+                raise ValueError(f"Function {func_name} not allowed")
+            args = [self.visit(arg) for arg in node.args]
+            return _ALLOWED_FUNCTIONS[func_name](*args)
+        else:
+            raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
+
+def evaluate_expression(expression: str) -> float:
+    """Safely evaluate a mathematical expression."""
+    try:
+        parsed = ast.parse(expression, mode='eval')
+        evaluator = SafeEval()
+        return evaluator.visit(parsed)
+    except Exception as exc:
+        raise ValueError(str(exc))

--- a/engineering_calculator/engineering_calculator/calculator_node.py
+++ b/engineering_calculator/engineering_calculator/calculator_node.py
@@ -1,0 +1,34 @@
+import rclpy
+from rclpy.node import Node
+
+from engineering_calculator.srv import CalculateExpression
+from .calc_lib import evaluate_expression
+
+
+class CalculatorService(Node):
+    def __init__(self):
+        super().__init__('calculator_service')
+        self.srv = self.create_service(
+            CalculateExpression,
+            'calculate_expression',
+            self.calculate_callback)
+
+    def calculate_callback(self, request, response):
+        try:
+            result = evaluate_expression(request.expression)
+            response.result = float(result)
+            response.error = ''
+        except Exception as exc:
+            response.result = float('nan')
+            response.error = str(exc)
+        return response
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = CalculatorService()
+    rclpy.spin(node)
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/engineering_calculator/engineering_calculator/srv/CalculateExpression.srv
+++ b/engineering_calculator/engineering_calculator/srv/CalculateExpression.srv
@@ -1,0 +1,4 @@
+string expression
+---
+float64 result
+string error

--- a/engineering_calculator/package.xml
+++ b/engineering_calculator/package.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>engineering_calculator</name>
+  <version>0.0.1</version>
+  <description>Scientific calculator implemented as a ROS2 (Foxy) service.</description>
+  <maintainer email="example@example.com">Example Maintainer</maintainer>
+  <license>MIT</license>
+  <exec_depend>rclpy</exec_depend>
+</package>

--- a/engineering_calculator/resource/engineering_calculator
+++ b/engineering_calculator/resource/engineering_calculator
@@ -1,0 +1,1 @@
+resource file

--- a/engineering_calculator/setup.cfg
+++ b/engineering_calculator/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/engineering_calculator
+[install]
+install_scripts=$base/lib/engineering_calculator

--- a/engineering_calculator/setup.py
+++ b/engineering_calculator/setup.py
@@ -1,0 +1,28 @@
+from setuptools import setup
+import os
+from glob import glob
+
+package_name = 'engineering_calculator'
+
+setup(
+    name=package_name,
+    version='0.0.1',
+    packages=[package_name],
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+    ],
+    install_requires=['setuptools', 'rclpy'],
+    zip_safe=True,
+    maintainer='Example Maintainer',
+    maintainer_email='example@example.com',
+    description='Scientific calculator service for ROS2 (Foxy).',
+    license='MIT',
+    tests_require=['pytest'],
+    entry_points={
+        'console_scripts': [
+            'calculator_server = engineering_calculator.calculator_node:main',
+        ],
+    },
+)

--- a/engineering_calculator/test/test_calc_lib.py
+++ b/engineering_calculator/test/test_calc_lib.py
@@ -1,0 +1,23 @@
+import math
+from engineering_calculator.calc_lib import evaluate_expression
+
+
+def test_basic_operations():
+    assert evaluate_expression('1 + 2 * 3') == 7
+    assert evaluate_expression('4 / 2') == 2
+    assert evaluate_expression('2 ** 3') == 8
+
+
+def test_functions():
+    assert evaluate_expression('sin(0)') == 0
+    assert math.isclose(evaluate_expression('cos(0)'), 1.0)
+    assert evaluate_expression('sqrt(4)') == 2
+
+
+def test_invalid_expression():
+    try:
+        evaluate_expression('import os')
+    except ValueError:
+        pass
+    else:
+        assert False, 'Expected ValueError for invalid expression'


### PR DESCRIPTION
## Summary
- add an engineering calculator ROS 2 package
- document how to build and test the ROS package
- implement a safe expression evaluator
- provide a ROS service node to evaluate expressions
- include unit tests for the evaluator

## Testing
- `PYTHONPATH=engineering_calculator pytest engineering_calculator/test/test_calc_lib.py -q`

------
https://chatgpt.com/codex/tasks/task_e_683fccda6430832485414bc5e401db0c